### PR TITLE
Add initial dockerfile to the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,86 @@
-Initial version of the README
+# Base Docker environment for libIEC61850
+This is a Docker environment that can host the mz-automation libIEC61850 project.
+
+## Building and Running the Docker Environment
+[Docker](https://www.docker.com/) must be installed on the machine before anything can proceed.
+
+In order to create this libIEC61850 container you must be in the "docker" folder and run the command
+
+> make build
+
+And let Docker do it's magic from there. Once the build is complete check that the Docker image is available with
+
+> docker images
+
+Should see an image called reserve/libiec61850.
+
+In order to run this image as a container for the first time run the script in the tools folder
+
+> ./dockerrun.sh
+
+The output from this command will show that the container can be run in development mode "dev".
+
+Now run the command in the preferred mode
+
+> ./dockerrun.sh -e dev
+
+To see whether the broker is up and running have a look in the log files
+
+> docker logs reserve-libiec61850-local
+
+In order to enter this Docker container when in development mode type the command
+
+> docker exec -it reserve-libiec61850-local bash
+
+
+You will be landed in to the shell of the container and the main directory were the libIEC61850 project is based.
+
+Of note the examples have already been built as part of the creation of the container image.
+
+The run the examples tests head to the folder "examples/iec61850_client_example1/"
+
+> cd examples/iec61850_client_example1/
+
+Read the "client_example1.c" file in here as it will tell you which server to run with the example.
+
+> more client_example1.c
+
+For example 1 it tells you that you must be running server_example_goose. In a seperate terminal window exec into the docker container a second time
+
+> docker exec -it reserve-libiec61850-local bash
+
+Go to the example server directory
+
+> cd examples/server_example_goose
+
+And run the server_example_goose
+
+> ./server_example_goose
+
+Head back to the first exec terminal where you should be in the folder "examples/iec61850_client_example1/" and run teh exmple client_example1
+
+> ./client_example1
+
+Should spot an output of
+```
+read float value: 0.600000
+RptEna = 0
+received report for simpleIOGenericIO/LLN0.RP.EventsRCB01
+  GGIO1.SPCSO0.stVal: 0 (included for reason 4)
+  GGIO1.SPCSO1.stVal: 0 (included for reason 4)
+  GGIO1.SPCSO2.stVal: 0 (included for reason 4)
+  GGIO1.SPCSO3.stVal: 0 (included for reason 4)
+```
+This example is now complete, you are free to test the other examples. 
+
+In order to exit from the shell, CRTL-D.
+
+In order to shutdown the running development container use the command
+
+> docker stop reserve-libiec61850-local
+
+To start the container again just type
+
+> docker start reserve-libiec61850-local
+
+Copyright Waterford Institute of Technology 2017, Telecommunications Software and Systems Group (TSSG), Author Miguel Ponce de Leon <miguelpdl@tssg.org>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+Initial version of the README

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Base Docker environment for libIEC61850
-This is a Docker environment that can host the RESERVE clone of the libIEC61850 project.
+This is a Docker environment that can host the clone of the libIEC61850 project.
 
 ## Building and Running the Docker Environment
 [Docker](https://www.docker.com/) must be installed on the machine before anything can proceed.
@@ -8,15 +8,13 @@ You must also have a GitLab access token from your own personal access tokens as
 
 In order to create this libIEC61850 container you must be in the "docker" folder and run the command
 
-> make gituseraccess="sam" gitaccesstoken="4a5wZhYKuGvd6ZgYL"
-
-Please note that the combination of "sam" and gitaccesstoken="4a5wZhYKuGvd6ZgYL" will not work, you must use your own details.
+> make build 
 
 Now let Docker do it's magic from there. Once the build is complete check that the Docker image is available with
 
 > docker images
 
-Should see an image called reserve/libiec61850.
+Should see an image called tssg/libiec61850.
 
 In order to run this image as a container for the first time run the script in the tools folder
 
@@ -30,11 +28,11 @@ Now run the command in the preferred mode
 
 To see whether the container is up and running have a look in the log files
 
-> docker logs reserve-libiec61850-local
+> docker logs tssg-libiec61850-local
 
 In order to enter this Docker container when in development mode type the command
 
-> docker exec -it reserve-libiec61850-local bash
+> docker exec -it tssg-libiec61850-local bash
 
 
 You will be landed in to the shell of the container and the main directory were the libIEC61850 project is based.
@@ -51,7 +49,7 @@ Read the "client_example1.c" file in here as it will tell you which server to ru
 
 For example 1 it tells you that you must be running server_example_goose. In a seperate terminal window exec into the docker container a second time
 
-> docker exec -it reserve-libiec61850-local bash
+> docker exec -it tssg-libiec61850-local bash
 
 Go to the example server directory
 
@@ -81,10 +79,11 @@ In order to exit from the shell, CRTL-D.
 
 In order to shutdown the running development container use the command
 
-> docker stop reserve-libiec61850-local
+> docker stop tssg-libiec61850-local
 
 To start the container again just type
 
-> docker start reserve-libiec61850-local
+> docker start tssg-libiec61850-local
 
 Copyright Waterford Institute of Technology 2017~2019, Telecommunications Software and Systems Group (TSSG), Author Miguel Ponce de Leon <miguelpdl@tssg.org>
+This work is supported by European Union’s Horizon 2020 research and innovation programme under grant agreement No 727481, project RE-SERVE (Re- newables in a Stable Electric Grid)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # Base Docker environment for libIEC61850
-This is a Docker environment that can host the mz-automation libIEC61850 project.
+This is a Docker environment that can host the RESERVE clone of the libIEC61850 project.
 
 ## Building and Running the Docker Environment
 [Docker](https://www.docker.com/) must be installed on the machine before anything can proceed.
 
+You must also have a GitLab access token from your own personal access tokens as enabled via Gitlab and outlined in https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html
+
 In order to create this libIEC61850 container you must be in the "docker" folder and run the command
 
-> make build
+> make gituseraccess="sam" gitaccesstoken="4a5wZhYKuGvd6ZgYL"
 
-And let Docker do it's magic from there. Once the build is complete check that the Docker image is available with
+Please note that the combination of "sam" and gitaccesstoken="4a5wZhYKuGvd6ZgYL" will not work, you must use your own details.
+
+Now let Docker do it's magic from there. Once the build is complete check that the Docker image is available with
 
 > docker images
 
@@ -71,7 +75,7 @@ received report for simpleIOGenericIO/LLN0.RP.EventsRCB01
   GGIO1.SPCSO2.stVal: 0 (included for reason 4)
   GGIO1.SPCSO3.stVal: 0 (included for reason 4)
 ```
-This example is now complete, you are free to test the other examples. 
+This example is now complete, you are free to test the other examples.
 
 In order to exit from the shell, CRTL-D.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Now run the command in the preferred mode
 
 > ./dockerrun.sh -e dev
 
-To see whether the broker is up and running have a look in the log files
+To see whether the container is up and running have a look in the log files
 
 > docker logs reserve-libiec61850-local
 

--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ To start the container again just type
 
 > docker start reserve-libiec61850-local
 
-Copyright Waterford Institute of Technology 2017, Telecommunications Software and Systems Group (TSSG), Author Miguel Ponce de Leon <miguelpdl@tssg.org>
+Copyright Waterford Institute of Technology 2017~2019, Telecommunications Software and Systems Group (TSSG), Author Miguel Ponce de Leon <miguelpdl@tssg.org>

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ This is a Docker environment that can host the clone of the libIEC61850 project.
 ## Building and Running the Docker Environment
 [Docker](https://www.docker.com/) must be installed on the machine before anything can proceed.
 
-You must also have a GitLab access token from your own personal access tokens as enabled via Gitlab and outlined in https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html
-
 In order to create this libIEC61850 container you must be in the "docker" folder and run the command
 
 > make build 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,13 +15,17 @@ ENV build_date 2017-11-10
 CMD ["/sbin/my_init"]
 
 # ...put your own build instructions here...
-RUN apt-get update && apt-get upgrade -y
+RUN apt-get update --fix-missing && apt-get upgrade -y
 
-RUN apt-get install git build-essential libsqlite3-dev -y
+RUN apt-get install git build-essential libsqlite3-dev default-jdk swig -y
 
 WORKDIR /opt
 
-RUN git clone https://github.com/mz-automation/libiec61850
+#Setting up the command line argument to pass in gituser access_token
+ARG gituser
+ARG access_token
+
+RUN git clone https://$gituser:$access_token@servo.tssg.org/re-serve/development/libiec61850.git
 
 WORKDIR /opt/libiec61850
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,31 @@
+# Copyright Waterford Institute of Technology 2017
+# Telecommunications Software and Systems Group (TSSG)
+# Author Miguel Ponce de Leon <miguelpdl@tssg.org>
+#
+# Using phusion/baseimage as base image. To make your builds
+# reproducible, make sure you lock down to a specific version, not
+# to `latest`! See
+# https://github.com/phusion/baseimage-docker/blob/master/Changelog.md
+# for a list of version numbers.
+FROM phusion/baseimage:0.9.22
+MAINTAINER Miguel Ponce de Leon <miguelpdl@tssg.org>
+ENV build_date 2017-11-10
+
+# Use baseimage-docker's init system.
+CMD ["/sbin/my_init"]
+
+# ...put your own build instructions here...
+RUN apt-get update && apt-get upgrade -y
+
+RUN apt-get install git build-essential libsqlite3-dev -y
+
+WORKDIR /opt
+
+RUN git clone https://github.com/mz-automation/libiec61850
+
+WORKDIR /opt/libiec61850
+
+RUN make examples
+
+# Clean up APT when done.
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,11 +21,7 @@ RUN apt-get install git build-essential libsqlite3-dev default-jdk swig -y
 
 WORKDIR /opt
 
-#Setting up the command line argument to pass in gituser access_token
-ARG gituser
-ARG access_token
-
-RUN git clone https://$gituser:$access_token@servo.tssg.org/re-serve/development/libiec61850.git
+RUN git clone https://github.com/TSSG/libiec61850.git 
 
 WORKDIR /opt/libiec61850
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright Waterford Institute of Technology 2017
+# Copyright Waterford Institute of Technology 2017~2019
 # Telecommunications Software and Systems Group (TSSG)
 # Author Miguel Ponce de Leon <miguelpdl@tssg.org>
 #
@@ -7,9 +7,9 @@
 # to `latest`! See
 # https://github.com/phusion/baseimage-docker/blob/master/Changelog.md
 # for a list of version numbers.
-FROM phusion/baseimage:0.9.22
+FROM phusion/baseimage:master
 MAINTAINER Miguel Ponce de Leon <miguelpdl@tssg.org>
-ENV build_date 2017-11-10
+ENV build_date 2019-10-04
 
 # Use baseimage-docker's init system.
 CMD ["/sbin/my_init"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,13 @@
+# Copyright Waterford Institute of Technology 2017
+# Telecommunications Software and Systems Group (TSSG)
+# Author Miguel Ponce de Leon <miguelpdl@tssg.org>
+
+# Build a container via the command
+#      > make build
+#
+# Need to ensure the Docker daemon is running before the build will run
+
+all:: build
+
+build:
+	docker build --rm -t reserve/libiec61850 .

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,25 +1,14 @@
-# Copyright Waterford Institute of Technology 2017
+# Copyright Waterford Institute of Technology 2017~2019
 # Telecommunications Software and Systems Group (TSSG)
 # Author Miguel Ponce de Leon <miguelpdl@tssg.org>
 #
 # Build a container via the example command
-#      > make gitaccesstoken="4a5wZhYKuGvd6ZgYL" build
+#      > make build
 #
-# The GitLab access token has to be your own personal access tokens as enabled via Gitlab and outlined in https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html
-# The gitaccesstoken="4a5wZhYKuGvd6ZgYL" in this example will not work.
 #
 # Need to ensure the Docker daemon is running before the build will run
 
 all:: build
 
-build: ## Must add your own GitLab username (gituseraccess="sam") and access token (gitaccesstoken="4a5wZhYKuGvd6ZgYL") as part of build arguments
-
-ifeq (${gituseraccess},)
-		@echo "There is no Git access username or token set to run this build"
-		@echo "For a GitLab access token read https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html"
-		@echo "Re-run the make command with your username and access token. For example like"
-		@echo "> make gituseraccess="sam" gitaccesstoken="4a5wZhYKuGvd6ZgYL" build"
-else
-		@echo "Running the Docker build"
-	  @docker build --rm -t reserve/libiec61850 --build-arg gituser=${gituseraccess} --build-arg access_token=${gitaccesstoken} .
-endif
+build: 
+	  docker build --rm -t tssg/libiec61850 .

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,13 +1,25 @@
 # Copyright Waterford Institute of Technology 2017
 # Telecommunications Software and Systems Group (TSSG)
 # Author Miguel Ponce de Leon <miguelpdl@tssg.org>
-
-# Build a container via the command
-#      > make build
+#
+# Build a container via the example command
+#      > make gitaccesstoken="4a5wZhYKuGvd6ZgYL" build
+#
+# The GitLab access token has to be your own personal access tokens as enabled via Gitlab and outlined in https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html
+# The gitaccesstoken="4a5wZhYKuGvd6ZgYL" in this example will not work.
 #
 # Need to ensure the Docker daemon is running before the build will run
 
 all:: build
 
-build:
-	docker build --rm -t reserve/libiec61850 .
+build: ## Must add your own GitLab username (gituseraccess="sam") and access token (gitaccesstoken="4a5wZhYKuGvd6ZgYL") as part of build arguments
+
+ifeq (${gituseraccess},)
+		@echo "There is no Git access username or token set to run this build"
+		@echo "For a GitLab access token read https://docs.gitlab.com/ce/user/profile/personal_access_tokens.html"
+		@echo "Re-run the make command with your username and access token. For example like"
+		@echo "> make gituseraccess="sam" gitaccesstoken="4a5wZhYKuGvd6ZgYL" build"
+else
+		@echo "Running the Docker build"
+	  @docker build --rm -t reserve/libiec61850 --build-arg gituser=${gituseraccess} --build-arg access_token=${gitaccesstoken} .
+endif

--- a/docker/dockerrun.sh
+++ b/docker/dockerrun.sh
@@ -20,12 +20,11 @@ END
 function run_container () {
 
 # Run the main container.
-# removed the user option for the moment =>  -u `id -u $USER` \
 
 docker run \
     --privileged \
     --name ${CONTAINER_NAME} \
-    -d -t reserve/libiec61850
+    -d -t tssg/libiec61850
 
 }
 
@@ -50,7 +49,7 @@ else
             fi
            elif [ "$2" == "dev" ] ; then
               # Give the container a meaningful name
-              CONTAINER_NAME=reserve-libiec61850-local
+              CONTAINER_NAME=tssg-libiec61850-local
 
               # Set the port
               #PORT="-p 1883:1883"

--- a/docker/dockerrun.sh
+++ b/docker/dockerrun.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Copyright Waterford Institute of Technology 2017
+# Telecommunications Software and Systems Group (TSSG)
+# Author Miguel Ponce de Leon <miguelpdl@tssg.org>
+
+# Run the command with a parameter
+# > ./dockerrun.sh -e prod reservemsgbroker.tssg.org
+
+function iHelp () {
+# Using a help doc with standard out.
+cat <<-END
+Usage:
+------
+  -e environment servername
+    e.g. -e dev
+END
+}
+
+function run_container () {
+
+# Run the main container.
+# removed the user option for the moment =>  -u `id -u $USER` \
+
+docker run \
+    --privileged \
+    --name ${CONTAINER_NAME} \
+    -d -t reserve/libiec61850
+
+}
+
+
+if [ -z "$1" ] ; then
+ iHelp
+ exit
+else
+ while [ -n "$1" ]; do
+   case "$1" in
+       -h | --help)
+           iHelp
+           exit
+           ;;
+       -e )
+           if [ "$2" == "prod" ] ; then
+             if [ -z "$3" ] ; then
+              iHelp
+              exit
+            else
+              exit
+            fi
+           elif [ "$2" == "dev" ] ; then
+              # Give the container a meaningful name
+              CONTAINER_NAME=reserve-libiec61850-local
+
+              # Set the port
+              #PORT="-p 1883:1883"
+
+              # Set up the volumes to be attached
+              #VOLUMES="-v $(pwd)/../src/local/conf/mosquitto.conf:/mosquitto/config/mosquitto.conf -v $(pwd)/../src/local/log/:/mosquitto/log/ "
+
+              #Run this Container
+              run_container
+              exit
+           else
+             iHelp
+             exit
+           fi
+           ;;
+   esac
+
+   iHelp
+   exit
+ done
+fi


### PR DESCRIPTION
This Docker container pulls in a [fork of the libiec61850 project from Github](https://github.com/TSSG/libiec61850), it can build all its examples and is also enhanced with Java functionality so that the Java JNI libiec61850 library can be built and used in the Java world.

To test this container, follow the [instructions of the README](https://github.com/TSSG/libiec61850-docker/blob/1-add-initial-dockerfile/README.md)